### PR TITLE
When a DistributedFuture times out, cancel the task and remove it from the queue

### DIFF
--- a/hazeltask-core/src/main/java/com/hazeltask/executor/DistributedFuture.java
+++ b/hazeltask-core/src/main/java/com/hazeltask/executor/DistributedFuture.java
@@ -54,4 +54,11 @@ public class DistributedFuture<GROUP extends Serializable, V> extends AbstractFu
     public long getCreatedTime() {
         return this.createdTime;
     }  
+    
+    GROUP getGroup() {
+    	return this.group;
+    }
+    UUID getTaskId() {
+    	return this.taskId; 
+    }
 }

--- a/hazeltask-core/src/main/java/com/hazeltask/executor/HazelcastExecutorTopologyService.java
+++ b/hazeltask-core/src/main/java/com/hazeltask/executor/HazelcastExecutorTopologyService.java
@@ -156,8 +156,12 @@ public class HazelcastExecutorTopologyService<GROUP extends Serializable> implem
     }
 
     public boolean removePendingTask(HazeltaskTask<GROUP> task) {
-        pendingTask.removeAsync(task.getId());
-        return true;
+        return removePendingTask(task.getId());
+    }
+    
+    public boolean removePendingTask(UUID taskId) {
+    	pendingTask.removeAsync(taskId);
+    	return true;
     }
 
     public void broadcastTaskCompletion(UUID taskId, Serializable response, Serializable taskInfo) {

--- a/hazeltask-core/src/main/java/com/hazeltask/executor/IExecutorTopologyService.java
+++ b/hazeltask-core/src/main/java/com/hazeltask/executor/IExecutorTopologyService.java
@@ -76,6 +76,7 @@ public interface IExecutorTopologyService<GROUP extends Serializable> {
      * @return true if removed, false it did not exist
      */
     public boolean removePendingTask(HazeltaskTask<GROUP> task);
+    public boolean removePendingTask(UUID taskId);
     
     public void broadcastTaskCompletion(UUID taskId, Serializable response, Serializable taskInfo);
     public void broadcastTaskCancellation(UUID taskId, Serializable taskInfo);


### PR DESCRIPTION
When a DistributedFuture times out, cancel the task and remove it from the queue. Otherwise it will remain in the pending tasks queue and get executed disjoined from any client side logic.

This is safe to do because onRemoval is fired after the DistributedFuture is already removed from the futures cache and will not raise a cancelation exception.
